### PR TITLE
Add context for the focused area.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ fadeDuration | Number | 700 | Duration of the overlay transition (milliseconds).
 hideOnClick | Boolean | false | Hides the overlay when the user click into it.
 hideOnESC | Boolean | false | Hides the overlay when the user press Esc.
 findOnResize | Boolean | false | Refind the element in the DOM in case that the element don't still exists.
+context | Selector  | 'body'  | Set the context for the focused area
 
 ###### Runing tests
 * `npm install`

--- a/sample_app/demo.js
+++ b/sample_app/demo.js
@@ -8,6 +8,9 @@
     function show() {
       var selector = $(this).attr('data-selector');
       var options = getOptions();
+      if ($(this).attr('data-context')) {
+        options.context = $(this).attr('data-context');
+      }
       Focusable.setFocus($(selector), options);
     }
 
@@ -21,7 +24,7 @@
       fadeDuration: parseInt($('#fade-duration').val()),
       hideOnClick: $('#hide-on-click').is(':checked'),
       hideOnESC: $('#hide-on-esc').is(':checked'),
-      findOnResize: $('#find-on-resize').is(':checked')
+      findOnResize: $('#find-on-resize').is(':checked'),
     };
   }
 })();

--- a/sample_app/index.html
+++ b/sample_app/index.html
@@ -50,6 +50,7 @@
       <button class="show" data-selector="ul">Focus list</button>
       <button class="show" data-selector="li:first">Focus first item</button>
       <button class="show" data-selector="img">Focus image</button>
+      <button class="show" data-selector="ul" data-context=".options">Focus list inside '.options' box</button>
     </header>
     <ul>
       <li>1</li>

--- a/test/tests.js
+++ b/test/tests.js
@@ -25,7 +25,7 @@
     Focusable.setFocus($element);
 
     ok(isActive(), true, 'The overlay is in DOM');
-    ok(Focusable.getActiveElement() == $element, true, 'The focused element is active');
+    ok(Focusable.getActiveElement()[0] == $element[0], true, 'The focused element is active');
   });
 
   test("jQuery plugin", function() {


### PR DESCRIPTION
Hi, I need to set the context of the opaque overlay in a project I'm working on, so I think it was useful to have an option that can be passed to specify the context of this area.
In real life I had to show a tutorial in a sidebar and guide the user through the app by highlighting the element in the app container leaving sidebar fully visible. I hope my effort is appreciated. Thanks.
